### PR TITLE
Use {spawn,Test} to isolate tests from each other

### DIFF
--- a/doc/eunit_addons.md
+++ b/doc/eunit_addons.md
@@ -39,6 +39,8 @@ name) to the eunit printout.
 
 * They make it easy to set timeouts for test cases.
 
+* The tests gets isolated from each other.
+
 
 
 
@@ -50,6 +52,10 @@ test module itself.  However, the version of the macro which
 has the `Tests` parameter might be useful when there are         
 different groups of tests in one module which require         
 different setup.
+
+
+
+The `{spawn,Test}` feature of eunit is used to achieve test isoloation.
 
 
 

--- a/include/eunit_addons.hrl
+++ b/include/eunit_addons.hrl
@@ -19,7 +19,7 @@
         {timeout, ForAllTimeout,           %% timeout for all tests
          [{timeout, PerTcTimeout,          %% timeout for each test
            [{atom_to_list(__Test),         %% label per test
-             fun() -> Fun(__Test) end}]}
+             {spawn, fun() -> Fun(__Test) end}}]}
           || __Test <- Tests]}).
 
 -define(WITH_FUN(Fun, ForAllTimeout, PerTcTimeout),
@@ -34,14 +34,14 @@
         {timeout, ForAllTimeout,           %% timeout for all tests
          [{timeout, PerTcTimeout,          %% timeout for each test
            [{atom_to_list(__Test),         %% label per test
-             fun() -> 
-                     Env = SetupFun(),
-                     try
-                         apply(?MODULE, __Test, [Env])
-                     after
-                         CleanupFun(Env)
-                     end
-             end}]}
+             {spawn, fun() ->
+                             Env = SetupFun(),
+                             try
+                                 apply(?MODULE, __Test, [Env])
+                             after
+                                 CleanupFun(Env)
+                             end
+                     end}}]}
           || __Test <- Tests]}).
 
 -define(WITH_SETUP(SetupFun, CleanupFun, ForAllTimeout, PerTcTimeout),

--- a/src/eunit_addons.erl
+++ b/src/eunit_addons.erl
@@ -54,6 +54,7 @@
 %%%     <li>They provide readable test names (same as the function
 %%%         name) to the eunit printout.</li>
 %%%     <li>They make it easy to set timeouts for test cases.</li>
+%%%     <li>The tests gets isolated from each other.</li>
 %%% </ul>
 %%%
 %%% NOTE: Use one of the ?WITH_SETUP macros with fewer parameters (if
@@ -63,6 +64,8 @@
 %%%       has the `Tests' parameter might be useful when there are
 %%%       different groups of tests in one module which require
 %%%       different setup.
+%%%
+%%% The `{spawn,Test}' feature of eunit is used to achieve test isoloation.
 %%%
 %%% === Run all ..._test/1 functions (with default timeouts) ===
 %%% This:

--- a/test/eunit_addons_tests.erl
+++ b/test/eunit_addons_tests.erl
@@ -61,3 +61,8 @@ with_setup_1_test(foo) ->
 with_setup_2_test(foo) ->
     ok.
 
+test_case_isolation_1_test(_) ->
+    put(a, dummy).
+
+test_case_isolation_2_test(_) ->
+    undefined = get(a).


### PR DESCRIPTION
Both the ?WITH_SETUP(...) and ?WITH_FUN(...) macros now
use the {spawn,Test} feature of eunit to isolate tests
from each other, for example tests that links to or monitors
other processes, or tests that clutter the process dictionary.
