### PR TITLE
Fix test descriptions in surefire xml

### DIFF
--- a/include/eunit_addons.hrl
+++ b/include/eunit_addons.hrl
@@ -18,8 +18,9 @@
 -define(WITH_FUN(Fun, ForAllTimeout, PerTcTimeout, Tests),
         {timeout, ForAllTimeout,           %% timeout for all tests
          [{timeout, PerTcTimeout,          %% timeout for each test
-           [{atom_to_list(__Test),         %% label per test
-             {spawn, fun() -> Fun(__Test) end}}]}
+           {spawn,
+            {atom_to_list(__Test),         %% label per test
+             fun() -> Fun(__Test) end}}}
           || __Test <- Tests]}).
 
 -define(WITH_FUN(Fun, ForAllTimeout, PerTcTimeout),
@@ -33,15 +34,16 @@
 -define(WITH_SETUP(SetupFun, CleanupFun, ForAllTimeout, PerTcTimeout, Tests),
         {timeout, ForAllTimeout,           %% timeout for all tests
          [{timeout, PerTcTimeout,          %% timeout for each test
-           [{atom_to_list(__Test),         %% label per test
-             {spawn, fun() ->
-                             Env = SetupFun(),
-                             try
-                                 apply(?MODULE, __Test, [Env])
-                             after
-                                 CleanupFun(Env)
-                             end
-                     end}}]}
+           {spawn,
+            {atom_to_list(__Test),         %% label per test
+             fun() ->
+                     Env = SetupFun(),
+                     try
+                         apply(?MODULE, __Test, [Env])
+                     after
+                         CleanupFun(Env)
+                     end
+             end}}}
           || __Test <- Tests]}).
 
 -define(WITH_SETUP(SetupFun, CleanupFun, ForAllTimeout, PerTcTimeout),


### PR DESCRIPTION
Move the description to the test, so that it is included in the surefire xml
file. This makes it possible to distinguish between different tests run by the
same generator.

Example XML entry before:
`<testcase time="0.000" name="eunit_addons_tests:0 with_fun_test_">
    <system-out>
    </system-out>
  </testcase>`

After:
`  <testcase time="0.000" name="eunit_addons_tests:0 with_fun_test_ (with_setup_1_test)">
    <system-out>
    </system-out>
  </testcase>`